### PR TITLE
키 훅으로 이동할 때 오프셋 주는 부분 수정

### DIFF
--- a/includes/ui.h
+++ b/includes/ui.h
@@ -6,7 +6,7 @@
 /*   By: seojilee <seojilee@student.42seoul.>       +# +  +:+       +# +      */
 /*                                                +# +# +# +# +# +   +# +     */
 /*   Created: 2023/12/02 12:59:13 by seojilee          # +#     # +#          */
-/*   Updated: 2023/12/06 08:55:31 by seojilee         ###   ########.fr       */
+/*   Updated: 2023/12/06 19:17:57 by seojilee         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -93,8 +93,6 @@ typedef struct s_data {
 	int		mouse_y;
 	int		center_x;
 	int		center_y;
-	int		key_x;
-	int		key_y;
 	double	zoom;
 	int		iter;
 	bool	button_on_off[BUTTONS];
@@ -136,7 +134,6 @@ void	make_all_false(t_data *img);
  * control keys
  */
 void	init_zoom_center(t_data *img);
-void	init_key_xy(t_data *img);
 void	control_key(int key, t_data *img);
 void	hook(t_data *img);
 

--- a/srcs/mandelbrot.c
+++ b/srcs/mandelbrot.c
@@ -6,12 +6,11 @@
 /*   By: seojilee <seojilee@student.42seoul.>       +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/12/02 16:02:25 by seojilee          #+#    #+#             */
-/*   Updated: 2023/12/06 18:12:34 by seojilee         ###   ########.fr       */
+/*   Updated: 2023/12/06 19:15:17 by seojilee         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
 #include "fractal.h"
-#include <stdio.h>
 
 void	mandelbrot(t_data *img)
 {
@@ -21,8 +20,8 @@ void	mandelbrot(t_data *img)
 	int			i;
 	int			j;
 
-	box_std.box_offset_x = BOXWIDTH / 2 - (img->center_x - img->key_x);
-	box_std.box_offset_y = BOXHEIGHT / 2 - (img->center_y - img->key_y);
+	box_std.box_offset_x = BOXWIDTH / 2 - (img->center_x);
+	box_std.box_offset_y = BOXHEIGHT / 2 - (img->center_y);
 	j = BOXTOP;
 	while (j <= BOXBOT)
 	{

--- a/srcs/mandelbrot.c
+++ b/srcs/mandelbrot.c
@@ -6,7 +6,7 @@
 /*   By: seojilee <seojilee@student.42seoul.>       +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/12/02 16:02:25 by seojilee          #+#    #+#             */
-/*   Updated: 2023/12/06 13:16:20 by seojilee         ###   ########.fr       */
+/*   Updated: 2023/12/06 18:12:34 by seojilee         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -33,7 +33,7 @@ void	mandelbrot(t_data *img)
 			init_complex(&c, \
 					((double)(i - BOXLEFT) - box_std.box_offset_x) * img->zoom, \
 					((double)(j - BOXTOP) - box_std.box_offset_y) * img->zoom);
-			img->iter = iter_complex(&z, c, 10, MANDELBROT);
+			img->iter = iter_complex(&z, c, ITER, MANDELBROT);
 			draw_mandelbrot(c_abs(z), img, i, j);
 			i++;
 		}

--- a/srcs/ui_key.c
+++ b/srcs/ui_key.c
@@ -6,7 +6,7 @@
 /*   By: seojilee <seojilee@student.42seoul.>       +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/12/02 13:52:38 by seojilee          #+#    #+#             */
-/*   Updated: 2023/12/06 13:14:38 by seojilee         ###   ########.fr       */
+/*   Updated: 2023/12/06 19:18:27 by seojilee         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -17,12 +17,6 @@ void	init_zoom_center(t_data *img)
 	img->zoom = 0.0035;
 	img->center_x = 0;
 	img->center_y = 0;
-}
-
-void	init_key_xy(t_data *img)
-{
-	img->key_x = 0;
-	img->key_y = 0;
 }
 
 void	control_key(int key, t_data *img)
@@ -44,7 +38,6 @@ void	control_key(int key, t_data *img)
 //		init_coordinate(img);
 		make_all_false(img);
 		init_zoom_center(img);
-		init_key_xy(img);
 		img->button_on_off[MANDELBROT] = true;
 		mandelbrot(img);
 	}
@@ -52,7 +45,6 @@ void	control_key(int key, t_data *img)
 //		init_coordinate(img);
 		make_all_false(img);
 		init_zoom_center(img);
-		init_key_xy(img);
 		img->button_on_off[JULIA] = true;
 		julia(img);
 	}
@@ -60,7 +52,6 @@ void	control_key(int key, t_data *img)
 //		init_coordinate(img);
 		make_all_false(img);
 		init_zoom_center(img);
-		init_key_xy(img);
 		img->button_on_off[BURNINGSHIP] = true;
 		burningship(img);
 	}
@@ -68,7 +59,6 @@ void	control_key(int key, t_data *img)
 //		init_coordinate(img);
 		make_all_false(img);
 		init_zoom_center(img);
-		init_key_xy(img);
 		img->button_on_off[TRICORN] = true;
 		tricorn(img);
 	}
@@ -79,19 +69,19 @@ void	control_key(int key, t_data *img)
 		logistic_map(img);
 	}
 	else if (key == KEY_LEFT) {
-		img->key_x += 80;
+		img->center_x -= 80;
 		call_set(img);
 	}
 	else if (key == KEY_RIGHT) {
-		img->key_x -= 80;
+		img->center_x += 80;
 		call_set(img);
 	}
 	else if (key == KEY_DOWN) {
-		img->key_y -= 80;
+		img->center_y += 80;
 		call_set(img);
 	}
 	else if (key == KEY_UP) {
-		img->key_y += 80;
+		img->center_y -= 80;
 		call_set(img);
 	}
 	write_menu(img);

--- a/srcs/ui_mouse.c
+++ b/srcs/ui_mouse.c
@@ -6,7 +6,7 @@
 /*   By: seojilee <seojilee@student.42seoul.>       +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/12/02 13:47:53 by seojilee          #+#    #+#             */
-/*   Updated: 2023/12/06 13:13:59 by seojilee         ###   ########.fr       */
+/*   Updated: 2023/12/06 18:12:32 by seojilee         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -33,7 +33,6 @@ void	wheel(int button, t_data *img)
 		img->zoom /= 1.5;
 		img->center_x *= 1.5;
 		img->center_y *= 1.5;
-		init_key_xy(img);
 		call_set(img);
 	}
 	if (button == WHEEL_DOWN)
@@ -43,7 +42,6 @@ void	wheel(int button, t_data *img)
 		img->zoom *= 1.5;
 		img->center_x /= 1.5;
 		img->center_y /= 1.5;
-		init_key_xy(img);
 		call_set(img);
 	}
 	if (button == WHEEL_CLICK)
@@ -109,8 +107,9 @@ int	mouse_press(int button, int x, int y, void *param)
 		{
 			if (y >= BOXTOP && y <= BOXBOT)
 			{
-				img->center_x += ((img->mouse_x - BOXLEFT) - BOXWIDTH / 2);
-				img->center_y += ((img->mouse_y - BOXTOP) - BOXHEIGHT / 2);
+				img->center_x += ((img->mouse_x - BOXLEFT) - BOXWIDTH / 2 - img->key_x);
+				img->center_y += ((img->mouse_y - BOXTOP) - BOXHEIGHT / 2 - img->key_y);
+				init_key_xy(img);
 				call_set(img);
 			}
 			write_menu(img);

--- a/srcs/ui_mouse.c
+++ b/srcs/ui_mouse.c
@@ -6,7 +6,7 @@
 /*   By: seojilee <seojilee@student.42seoul.>       +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/12/02 13:47:53 by seojilee          #+#    #+#             */
-/*   Updated: 2023/12/06 18:12:32 by seojilee         ###   ########.fr       */
+/*   Updated: 2023/12/06 19:19:36 by seojilee         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -47,7 +47,6 @@ void	wheel(int button, t_data *img)
 	if (button == WHEEL_CLICK)
 	{
 		init_zoom_center(img);
-		init_key_xy(img);
 		call_set(img);
 	}
 	write_menu(img);
@@ -107,9 +106,8 @@ int	mouse_press(int button, int x, int y, void *param)
 		{
 			if (y >= BOXTOP && y <= BOXBOT)
 			{
-				img->center_x += ((img->mouse_x - BOXLEFT) - BOXWIDTH / 2 - img->key_x);
-				img->center_y += ((img->mouse_y - BOXTOP) - BOXHEIGHT / 2 - img->key_y);
-				init_key_xy(img);
+				img->center_x += ((img->mouse_x - BOXLEFT) - BOXWIDTH / 2);
+				img->center_y += ((img->mouse_y - BOXTOP) - BOXHEIGHT / 2);
 				call_set(img);
 			}
 			write_menu(img);


### PR DESCRIPTION
키 훅으로 이동을 할 때 센터 오프셋 연산을 먼저 한 다음에 키 오프셋을 추가적으로 줘서 확대할 때 원래 이동해야 하는 범위보다 더 많이 이동하는 오차가 발생함.
그냥 센터 오프셋에 바로 키 오프셋을 추가해서 해결함. 역시전 역시전